### PR TITLE
Fix docs to work with latest snapshot version

### DIFF
--- a/mindmaps-docs/pom.xml
+++ b/mindmaps-docs/pom.xml
@@ -9,7 +9,7 @@
     <version>0.4.0</version>
 
     <properties>
-        <mindmaps.version>0.4.0</mindmaps.version>
+        <mindmaps.version>0.5.0-SNAPSHOT</mindmaps.version>
     </properties>
 
     <build>

--- a/pages/documentation/3-core-api/advanced-schema-definition.md
+++ b/pages/documentation/3-core-api/advanced-schema-definition.md
@@ -144,13 +144,21 @@ The addition of the rules specified above can be expressed via an insert Graql s
 ```graql
 insert
 "R1" isa inference-rule,
-lhs {(parent $x, child $y) isa Parent},
-rhs {(ancestor $x, descendant $y) isa Ancestor};
+lhs {
+    (parent: $x, child: $y) isa Parent;
+},
+rhs {
+    (ancestor: $x, descendant: $y) isa Ancestor;
+};
 
 "R2" isa inference-rule,
-lhs {(parent $x, child $z) isa Parent;
-(ancestor $z, descendant $y) isa Ancestor select $x, $y},
-rhs {(ancestor $x, descendant $y) isa Ancestor};
+lhs {
+    (parent: $x, child: $z) isa Parent;
+    (ancestor: $z, descendant: $y) isa Ancestor;
+},
+rhs {
+    (ancestor: $x, descendant: $y) isa Ancestor;
+};
 ```
 
 {% include links.html %}


### PR DESCRIPTION
If you want to run tests against the snapshot version, you should clone mindmapsdb and run `mvn install -DskipTests`
then you can run the tests here with `mvn test`
